### PR TITLE
chiralExplorer - updated UVbound pt.2

### DIFF
--- a/chiralExplorer.py
+++ b/chiralExplorer.py
@@ -17,23 +17,27 @@ import matplotlib.pyplot as plt
 Temp=300.
 #light quark mass
 ml=50
+#strange quark mass
+ms=ml
 #chem potential
 mu=50
 #described as crucial to the linear Regge behavior of meson spectrum
-#which is intreoduced in the bulk scalar mass, m2-5 (in MeV)
+#which is intreoduced in the bulk scalar mass, m2-5 (in MeV, Fang)
 mu_g = 440 
+#zeta, normalization constant which is defined by n_c, number of colors
+n_c = 3
+zeta = np.sqrt(n_c)/(2*np.pi)
 
 #value of the cube root of chiral condensate in MeV
 #386-387 MeV
 sl=483
 
 
-
 def chiral(y,u,params):
     global chi,chip
     chi,chip=y
-
-    v3,v4,zh,q,lam,gam,muc=params
+    
+    v3,v4,zh,q,lam,gam,mu_c=params
 
     
     Q=q*zh**3
@@ -49,7 +53,7 @@ def chiral(y,u,params):
     fp= -4*(1+Q**2)*u**3 + 6*Q**2*u**5
     "EOM for chiral field"
     derivs=[chip,
-          -chip * (fp/f + 3/(zh*u) - phip) + 1/(u*f) * (chi*(-3 - muc**2 * zh**2) + chi**3 *lam + chi**2*(gam/(2 * np.sqrt(2))))]          
+          -chip * (fp/f + 3/(zh*u) - phip) + 1/(u*f) * (chi*(-3 - mu_c**2 * zh**2) + chi**3 *lam + chi**2*(gam/(2 * np.sqrt(2))))]          
     return derivs
 
 "solve for horizon and charge"
@@ -82,11 +86,11 @@ gam=-22.6
 "Lambda"
 lam=16.8
 
-muc=1200
+mu_c=1200
 
 #sigmal=260**3
 
-params=v3,v4,zh,q,lam,gam,muc 
+params=v3,v4,zh,q,lam,gam,mu_c 
 
 "blackness function and its derivative, Reissner-Nordstrom metric"
 "This version is for finite temp, finite chemical potential"
@@ -94,14 +98,18 @@ f = 1 - (1+Q**2)*u**4 + Q**2*u**6
 fp = -4*(1+Q**2)*u**3 + 6*Q**2*u**5
 
 sigmal = sl**3
-UVbound = [ml*eta*zh*ui + sigmal/eta*(zh*ui)**3, ml*eta*zh + 3*sigmal/eta*zh**3*ui**2]
+#z is very VERY close to zero
+#(old) UVbound = [ml*eta*zh*ui + sigmal/eta*(zh*ui)**3, ml*eta*zh + 3*sigmal/eta*zh**3*ui**2]
+#new UVbound from Fang eqn. 11, [chi, chip]
+UVbound = [ml*zeta*(zh*ui)-((ml*ms*gam*zeta**2)/(2*np.sqrt(2)))*(zh*ui)**2 + (sigmal/zeta)*(zh*ui)**3 + 0.0625*ml*zeta*((-ms**2)*(gam**2)*(zeta**2) - (ml**2)*(gam**2)*(zeta**2) + 8*(ms**2)*(zeta**2)*gam + 16*(mu_g**2) - 8*(mu_c**2)) * ((zh*ui)**3)*np.log(zh*ui),   
+           ml*zeta*(zh)-2*((ml*ms*gam*zeta**2)/(2*np.sqrt(2)))*(zh**2*ui) + 3*(sigmal/zeta)*(zh**3*ui**2) + 0.0625*ml*zeta*((-ms**2)*(gam**2)*(zeta**2) - (ml**2)*(gam**2)*(zeta**2) + 8*(ms**2)*(zeta**2)*gam + 16*(mu_g**2) - 8*(mu_c**2)) * zh**3*(3*ui**2*np.log(zh*ui)+ui**2)]
 
 "solve for the chiral field"
 chiFields=odeint(chiral,UVbound,u,args=(params,))
 
 "test function defined to find when the chiral field doesn't diverge"
 "When test function is zero at uf, the chiral field doesn't diverge"
-test = -u**2 * chip*fp/f - 1/f *(chi*(-3-muc**2*u**2*zh**2) + (chi**3*(gam/ 2*np.sqrt(2))) + lam*chi**2)
+test = -u**2 * chip*fp/f - 1/f *(chi*(-3-mu_c**2*u**2*zh**2) + (chi**3*(gam/ 2*np.sqrt(2))) + lam*chi**2)
 testIR = test[umesh-1]#value of test function at uf
 
 #chiralPot=v3*chiFields[:,0]**3+v4*chiFields[:,0]**4


### PR DESCRIPTION
changed UVbound to Fang eqn.11
- added zeta (normalization constant)
- added n_c (for zeta, number of colors)
- added ms (strange quark mass, set equal to ml)
- kept test function and globals from must up-to-date main branch